### PR TITLE
Fix restepping needed detection

### DIFF
--- a/com.github.sdbg.debug.core/src/com/github/sdbg/debug/core/internal/webkit/model/WebkitDebugTarget.java
+++ b/com.github.sdbg.debug.core/src/com/github/sdbg/debug/core/internal/webkit/model/WebkitDebugTarget.java
@@ -345,7 +345,7 @@ public class WebkitDebugTarget extends WebkitDebugElement implements IBreakpoint
       }
     });
     connection.getPage().enable();
-
+    connection.getDom().enable();
     connection.getCSS().enable();
 
     connection.getDom().addDomListener(new DomListener() {

--- a/com.github.sdbg.debug.core/src/com/github/sdbg/debug/core/internal/webkit/model/WebkitResteppingManagerImpl.java
+++ b/com.github.sdbg.debug.core/src/com/github/sdbg/debug/core/internal/webkit/model/WebkitResteppingManagerImpl.java
@@ -59,7 +59,8 @@ public class WebkitResteppingManagerImpl implements WebkitResteppingManager {
       restep = true;
       return;
     } else if (SDBGDebugCorePlugin.getPlugin().getUseSmartStepOver() && exception == null
-        && reason == PausedReasonType.other && currentLocation != null && stepLocation != null
+        && reason == PausedReasonType.other && currentLocation != null && stepLocation != null 
+        && stepCommand != null
         && currentLocation.getPath().equals(stepLocation.getPath())
         && currentLocation.getLine() == stepLocation.getLine()) {
       // Restepping is needed if we are still on the same line in the same Java source file

--- a/com.github.sdbg.debug.core/src/com/github/sdbg/debug/core/internal/webkit/protocol/WebkitDom.java
+++ b/com.github.sdbg.debug.core/src/com/github/sdbg/debug/core/internal/webkit/protocol/WebkitDom.java
@@ -586,6 +586,14 @@ public class WebkitDom extends WebkitDomain {
     }
   }
 
+  public void disable() throws IOException {
+    sendSimpleCommand("DOM.disable");
+  }
+
+  public void enable() throws IOException {
+    sendSimpleCommand("DOM.enable");
+  }
+
   protected void handleDOMNotification(String method, JSONObject params) {
     if (method.equals(DOM_DOCUMENT_UPDATED)) {
       for (DomListener listener : domListeners) {


### PR DESCRIPTION
May be related to #135.
Resuming execution after breakpoint's hit without stepping leads to WebkitResteppingManagerImpl.isResteppingNeeded == true. But stepCommand is null at the same time.
This leads to wrong chrome request at the next breakpoint's hit.