### PR TITLE
Revert "Replace GPE extension with GWT Eclipse Plugin (V3) extension."

### DIFF
--- a/com.github.sdbg.integration.jdt/META-INF/MANIFEST.MF
+++ b/com.github.sdbg.integration.jdt/META-INF/MANIFEST.MF
@@ -19,7 +19,7 @@ Require-Bundle: org.eclipse.core.runtime,
  com.github.sdbg.debug.core,
  com.github.sdbg.debug.ui,
  org.eclipse.ui,
- com.gwtplugins.gdt.eclipse.core;resolution:=optional
+ com.google.gdt.eclipse.core;resolution:=optional
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.core.commands,

--- a/com.github.sdbg.integration.jdt/plugin.xml
+++ b/com.github.sdbg.integration.jdt/plugin.xml
@@ -144,7 +144,7 @@
    
     <!-- GWT Plugin debug launching -->
    <extension
-         point="com.gwtplugins.gdt.eclipse.core.debugLauncher">
+         point="com.google.gdt.eclipse.core.debugLauncher">
       <extensions
             class="com.github.sdbg.integration.jdt.ChromeDebugLaunch" 
             label="SDBG Chrome JS Debugger">

--- a/com.github.sdbg.integration.jdt/src/com/github/sdbg/integration/jdt/ChromeDebugLaunch.java
+++ b/com.github.sdbg.integration.jdt/src/com/github/sdbg/integration/jdt/ChromeDebugLaunch.java
@@ -25,6 +25,38 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.dialogs.ElementListSelectionDialog;
 
 public class ChromeDebugLaunch implements IDebugLaunch {
+  @Override
+  public void launch(IProject project, String url, String mode) {
+    if (project == null || url == null || mode == null) {
+      return;
+    }
+
+    try {
+      ILaunchConfiguration config;
+
+      try {
+        // Select an existing configuration if one exists
+        config = findConfig(project, url);
+      } catch (OperationCanceledException ex) {
+        return;
+      }
+
+      if (config == null) {
+        // Otherwise, create a new one
+        config = createConfig(project, url);
+      }
+
+      // Launch the configuration
+      SDBGLaunchConfigWrapper launchWrapper = new SDBGLaunchConfigWrapper(config);
+      launchWrapper.markAsLaunched();
+
+      LaunchUtils.clearConsoles();
+      LaunchUtils.launch(config, mode);
+    } catch (CoreException e) {
+      SDBGJDTIntegrationPlugin.wrapError(e);
+    }
+  }
+
   private ILaunchConfiguration chooseConfig(List<ILaunchConfiguration> configList) {
     IDebugModelPresentation labelProvider = DebugUITools.newDebugModelPresentation();
     ElementListSelectionDialog dialog = new ElementListSelectionDialog(
@@ -44,8 +76,7 @@ public class ChromeDebugLaunch implements IDebugLaunch {
 
   private ILaunchConfiguration createConfig(IProject project, String url) throws CoreException {
     ILaunchManager manager = DebugPlugin.getDefault().getLaunchManager();
-    ILaunchConfigurationType type = manager.getLaunchConfigurationType(
-        SDBGDebugCorePlugin.CHROME_LAUNCH_CONFIG_ID);
+    ILaunchConfigurationType type = manager.getLaunchConfigurationType(SDBGDebugCorePlugin.CHROME_LAUNCH_CONFIG_ID);
     ILaunchConfigurationWorkingCopy launchConfig = type.newInstance(
         null,
         manager.generateLaunchConfigurationName(project.getName()));
@@ -103,38 +134,6 @@ public class ChromeDebugLaunch implements IDebugLaunch {
   private ILaunchConfigurationType getConfigurationType() {
     ILaunchManager manager = DebugPlugin.getDefault().getLaunchManager();
     return manager.getLaunchConfigurationType(SDBGDebugCorePlugin.CHROME_LAUNCH_CONFIG_ID);
-  }
-
-  @Override
-  public void launch(IProject project, String url, String mode) {
-    if (project == null || url == null || mode == null) {
-      return;
-    }
-
-    try {
-      ILaunchConfiguration config;
-
-      try {
-        // Select an existing configuration if one exists
-        config = findConfig(project, url);
-      } catch (OperationCanceledException ex) {
-        return;
-      }
-
-      if (config == null) {
-        // Otherwise, create a new one
-        config = createConfig(project, url);
-      }
-
-      // Launch the configuration
-      SDBGLaunchConfigWrapper launchWrapper = new SDBGLaunchConfigWrapper(config);
-      launchWrapper.markAsLaunched();
-
-      LaunchUtils.clearConsoles();
-      LaunchUtils.launch(config, mode);
-    } catch (CoreException e) {
-      SDBGJDTIntegrationPlugin.wrapError(e);
-    }
   }
 
   private boolean testSimilar(IProject project, String url, ILaunchConfiguration config) {

--- a/com.github.sdbg.releng.targetplatform/com.github.sdbg.releng.targetplatform.target
+++ b/com.github.sdbg.releng.targetplatform/com.github.sdbg.releng.targetplatform.target
@@ -7,8 +7,8 @@
 <repository location="http://download.eclipse.org/releases/luna"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="com.gwtplugins.eclipse.suite.v3.feature" version="0.0.0"/>
-<repository location="http://storage.googleapis.com/gwt-eclipse-plugin/v3/release"/>
+<unit id="com.google.gdt.eclipse.suite.e44.feature.feature.group" version="0.0.0"/>
+<repository location="http://storage.googleapis.com/gwt-eclipse-plugin/release"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
Reverts temporarily sdbg/sdbg#150

Problem is:
[ERROR] Failed to resolve target definition C:\Users\Ivan\git\sdbg\com.github.sd
bg.releng.targetplatform\com.github.sdbg.releng.targetplatform.target: Could not
 find "com.gwtplugins.eclipse.suite.v3.feature/0.0.0" in the repositories of the
 current location -> [Help 1]
[ERROR]

Are you sure you have pushed to http://storage.googleapis.com/gwt-eclipse-plugin/v3/release ?
There is no feature com.gwtplugins.eclipse.suite.v3.feature in there, it seems?