### PR TITLE
Build with JAVA >= 11 and a more recent version of eclipse (eclipse-2021-12)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+*.class

--- a/com.github.sdbg.debug.core/pom.xml
+++ b/com.github.sdbg.debug.core/pom.xml
@@ -6,7 +6,7 @@
   
   <parent>
     <groupId>com.github.sdbg</groupId>
-    <version>1.0.10.qualifier</version>
+    <version>1.0.10-SNAPSHOT</version>
     <artifactId>com.github.sdbg.parent</artifactId>
   </parent>
 

--- a/com.github.sdbg.debug.core_test/pom.xml
+++ b/com.github.sdbg.debug.core_test/pom.xml
@@ -6,7 +6,7 @@
   
   <parent>
     <groupId>com.github.sdbg</groupId>
-    <version>1.0.10.qualifier</version>
+    <version>1.0.10-SNAPSHOT</version>
     <artifactId>com.github.sdbg.parent</artifactId>
   </parent>
 

--- a/com.github.sdbg.debug.ui/pom.xml
+++ b/com.github.sdbg.debug.ui/pom.xml
@@ -6,7 +6,7 @@
   
   <parent>
     <groupId>com.github.sdbg</groupId>
-    <version>1.0.10.qualifier</version>
+    <version>1.0.10-SNAPSHOT</version>
     <artifactId>com.github.sdbg.parent</artifactId>
   </parent>
 

--- a/com.github.sdbg.feature/pom.xml
+++ b/com.github.sdbg.feature/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>com.github.sdbg</groupId>
-    <version>1.0.10.qualifier</version>
+    <version>1.0.10-SNAPSHOT</version>
     <artifactId>com.github.sdbg.parent</artifactId>
   </parent>
 

--- a/com.github.sdbg.integration.jdt/pom.xml
+++ b/com.github.sdbg.integration.jdt/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.github.sdbg</groupId>
-    <version>1.0.10.qualifier</version>
+    <version>1.0.10-SNAPSHOT</version>
     <artifactId>com.github.sdbg.parent</artifactId>
   </parent>
   <artifactId>com.github.sdbg.integration.jdt</artifactId>

--- a/com.github.sdbg.releng.p2/pom.xml
+++ b/com.github.sdbg.releng.p2/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>com.github.sdbg</groupId>
-    <version>1.0.10.qualifier</version>
+    <version>1.0.10-SNAPSHOT</version>
     <artifactId>com.github.sdbg.parent</artifactId>
   </parent>
 

--- a/com.github.sdbg.releng.targetplatform/com.github.sdbg.releng.targetplatform.target
+++ b/com.github.sdbg.releng.targetplatform/com.github.sdbg.releng.targetplatform.target
@@ -2,9 +2,9 @@
 <?pde version="3.8"?><target name="com.github.sdbg.releng.targetplatform" sequenceNumber="6">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.pde.feature.group" version="3.10.1.v20150204-1700"/>
-<unit id="org.eclipse.jdt.feature.group" version="3.10.1.v20150204-1700"/>
-<repository location="http://download.eclipse.org/releases/luna"/>
+<unit id="org.eclipse.pde.feature.group" version="3.14.1000.v20211124-1800"/>
+<unit id="org.eclipse.jdt.feature.group" version="3.18.1000.v20211124-1800"/>
+<repository location="http://download.eclipse.org/releases/2021-12"/>
 </location>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="com.gwtplugins.eclipse.suite.v3.feature.feature.group" version="0.0.0"/>

--- a/com.github.sdbg.releng.targetplatform/pom.xml
+++ b/com.github.sdbg.releng.targetplatform/pom.xml
@@ -6,7 +6,7 @@
   
   <parent>
     <groupId>com.github.sdbg</groupId>
-    <version>1.0.10.qualifier</version>
+    <version>1.0.10-SNAPSHOT</version>
     <artifactId>com.github.sdbg.parent</artifactId>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,15 +5,15 @@
 
   <groupId>com.github.sdbg</groupId>
   <artifactId>com.github.sdbg.parent</artifactId>
-  <version>1.0.10.qualifier</version>
+  <version>1.0.10-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>
-    <tycho-version>0.22.0</tycho-version>
-    <tycho-extras-version>0.22.0</tycho-extras-version>
+    <tycho-version>2.7.0</tycho-version>
+    <tycho-extras-version>2.7.0</tycho-extras-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     
-    <eclipse.target>luna</eclipse.target>
+    <eclipse.target>2021-12</eclipse.target>
     <eclipse-repo.url>http://download.eclipse.org/releases/${eclipse.target}</eclipse-repo.url>
   </properties>
   
@@ -63,7 +63,7 @@
 		   <artifact>  
 		    <groupId>com.github.sdbg</groupId>  
 		    <artifactId>com.github.sdbg.releng.targetplatform</artifactId>  
-		    <version>1.0.10.qualifier</version>  
+		    <version>1.0.10-SNAPSHOT</version>  
 		   </artifact>  
 		  </target>  
         </configuration>  


### PR DESCRIPTION
- Updated to allow maven build with JDK11 and greater.
- Use a more current version of eclipse for building. replaced 8 years old luna with eclipse-2021-12