### PR TITLE
Support to find Microsoft Edge automatically

### DIFF
--- a/com.github.sdbg.debug.core/src/com/github/sdbg/debug/core/internal/util/BrowserManager.java
+++ b/com.github.sdbg.debug.core/src/com/github/sdbg/debug/core/internal/util/BrowserManager.java
@@ -646,12 +646,12 @@ public class BrowserManager {
       }
 
       //Default PATH. Often installed here.
-      file = findBrowserExecutable("default path", "C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe", false);
+      file = findBrowserExecutable("default path", "C:/Program Files (x86)/Microsoft/Edge/Application/msedge.exe", true);
       if (file != null) {
         return file;
       }
       
-      file = findBrowserExecutable("default path", "C:/Program Files/Microsoft/Edge/Application/msedge.exe", false);
+      file = findBrowserExecutable("default path", "C:/Program Files/Microsoft/Edge/Application/msedge.exe", true);
       if (file != null) {
         return file;
       }


### PR DESCRIPTION
In addition to Issue #21, this change will no longer require to manually specify Edge location. It will be found automatically if installed in standard directory.

Also added -Dbrowser.location as parameter to set executable path, because it is no longer chrome only. For compatibility -Dchrome.location will work also. Same is true for environment variable BROWSER_LOCATION and CHROME_LOCATION
