### PR TITLE
Send a resume event for WebkitDebugTarget to fix the pause icon on the process.

### DIFF
--- a/com.github.sdbg.debug.core/src/com/github/sdbg/debug/core/internal/webkit/model/WebkitDebugThread.java
+++ b/com.github.sdbg.debug.core/src/com/github/sdbg/debug/core/internal/webkit/model/WebkitDebugThread.java
@@ -260,6 +260,7 @@ public class WebkitDebugThread extends WebkitDebugElement implements ISDBGThread
     expectedResumeReason = DebugEvent.UNSPECIFIED;
 
     fireResumeEvent(reason);
+    getTarget().fireResumeEvent(DebugEvent.RESUME);
   }
 
   private IStackFrame[] createFrames(List<WebkitCallFrame> webkitFrames,


### PR DESCRIPTION
Fixes #172